### PR TITLE
Make current entity available in buildForm method

### DIFF
--- a/src/Admin/AbstractMediaAdmin.php
+++ b/src/Admin/AbstractMediaAdmin.php
@@ -35,7 +35,7 @@ abstract class AbstractMediaAdmin extends AbstractAdmin
             ]);
     }
 
-    public function buildForm(FormCollection $collection)
+    public function buildForm(FormCollection $collection, BaseEntity $entity)
     {
         $collection
             ->add('title', TextType::class)

--- a/src/Admin/AbstractUserAdmin.php
+++ b/src/Admin/AbstractUserAdmin.php
@@ -30,7 +30,7 @@ abstract class AbstractUserAdmin extends AbstractAdmin
         ]);
     }
 
-    public function buildForm(FormCollection $collection)
+    public function buildForm(FormCollection $collection, BaseEntity $entity)
     {
         $collection
             ->add('username', TextType::class)

--- a/src/Admin/AdminInterface.php
+++ b/src/Admin/AdminInterface.php
@@ -11,7 +11,7 @@ use Doctrine\ORM\QueryBuilder;
 
 interface AdminInterface
 {
-    public function buildForm(FormCollection $collection);
+    public function buildForm(FormCollection $collection, BaseEntity $entity);
     public function buildList(ListCollection $collection);
     public function extendQuery(QueryBuilder $queryBuilder);
     public function getAdminMenuGroup(): ?string;

--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -361,7 +361,7 @@ class CRUDController
     protected function buildForm(AdminInterface $admin, BaseEntity $data): FormInterface
     {
         $formCollection = new FormCollection();
-        $admin->buildForm($formCollection);
+        $admin->buildForm($formCollection, $data);
 
         $formUrl = (
             $data->getId() ?


### PR DESCRIPTION
To be able to configure the form fields based on the current entity, the entity should be available in the `buildForm` method.